### PR TITLE
Fix task bugs and add search filter

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -14,11 +14,14 @@ def list_tasks(status: str | None = None, q: str | None = None) -> list[dict[str
     for task in tasks:
         # Instructor note: intentional bug for the lab.
         # This uses the literal string "status" instead of the query parameter value.
-        if status and task["status"] != "status":
+        if status and task["status"] != status:
             continue
 
-        # Instructor note: partial feature for the lab.
-        # The route already accepts `q`, but search is not implemented yet.
+        if q:
+            haystack = f'{task.get("title", "")} {task.get("description", "")}'.lower()
+            if q.lower() not in haystack:
+                continue
+
         filtered.append(task)
 
     return filtered
@@ -53,12 +56,9 @@ def complete_task(task_id: int) -> dict[str, Any] | None:
 
     for task in tasks:
         if task["id"] == task_id:
-            updated_task = dict(task)
-            updated_task["status"] = "done"
-            updated_task["completed_at"] = datetime.now(timezone.utc).isoformat()
-
-            # Instructor note: intentional bug for the lab.
-            # The updated task is returned, but the stored list is never updated or saved.
-            return updated_task
+            task["status"] = "done"
+            task["completed_at"] = datetime.now(timezone.utc).isoformat()
+            save_tasks(tasks)
+            return task
 
     return None


### PR DESCRIPTION
## Summary
- fix the GET /tasks status filter to use the provided status value
- persist task completion through the JSON storage layer
- add case-insensitive q filtering across title and description
- keep data/tasks.json restored so the PR only contains code changes

## Verification
- GET /tasks?status=open returns only open tasks
- GET /tasks?status=done returns only done tasks
- POST /tasks/1/complete followed by GET /tasks/1 shows persistence
- GET /tasks?q=WORKSHOP, GET /tasks?q=oauth, and GET /tasks?status=open&q=launch return the expected matches