### PR TITLE
Fix task filtering, search, and completion persistence

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -10,15 +10,18 @@ def list_tasks(status: str | None = None, q: str | None = None) -> list[dict[str
     """Return task records, optionally filtered by status and search text."""
     tasks = load_tasks()
     filtered: list[dict[str, Any]] = []
+    query = q.lower() if q is not None else None
 
     for task in tasks:
-        # Instructor note: intentional bug for the lab.
-        # This uses the literal string "status" instead of the query parameter value.
-        if status and task["status"] != "status":
+        if status and task["status"] != status:
             continue
 
-        # Instructor note: partial feature for the lab.
-        # The route already accepts `q`, but search is not implemented yet.
+        if query:
+            title = task["title"].lower()
+            description = task["description"].lower()
+            if query not in title and query not in description:
+                continue
+
         filtered.append(task)
 
     return filtered
@@ -51,14 +54,14 @@ def complete_task(task_id: int) -> dict[str, Any] | None:
     """Mark a task as completed."""
     tasks = load_tasks()
 
-    for task in tasks:
+    for index, task in enumerate(tasks):
         if task["id"] == task_id:
             updated_task = dict(task)
             updated_task["status"] = "done"
             updated_task["completed_at"] = datetime.now(timezone.utc).isoformat()
 
-            # Instructor note: intentional bug for the lab.
-            # The updated task is returned, but the stored list is never updated or saved.
+            tasks[index] = updated_task
+            save_tasks(tasks)
             return updated_task
 
     return None


### PR DESCRIPTION
## Summary
- Make `/tasks` honor the `status` query value instead of comparing against a literal string, so status filters return expected results.
- Add case-insensitive `q` filtering across task titles and descriptions so clients can search tasks from query params.
- Persist completion updates in `complete_task` so `status=done` and `completed_at` survive subsequent reads.

## Verification
- Confirmed `curl \"http://127.0.0.1:8000/tasks?q=launch\"`, `curl \"http://127.0.0.1:8000/tasks?q=report\"`, and `curl \"http://127.0.0.1:8000/tasks?status=open&q=plan\"` each return the expected records.
- Confirmed completing a task is persisted and re-fetching the task still shows `status=done` with non-null `completed_at`.
- Reviewed `data/tasks.json`; runtime test data was restored and is not included in this PR.