### PR TITLE
Fix task bugs and add search filter

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -11,14 +11,18 @@ def list_tasks(status: str | None = None, q: str | None = None) -> list[dict[str
     tasks = load_tasks()
     filtered: list[dict[str, Any]] = []
 
+    query = q.lower() if q else None
+
     for task in tasks:
-        # Instructor note: intentional bug for the lab.
-        # This uses the literal string "status" instead of the query parameter value.
-        if status and task["status"] != "status":
+        # Filter by the requested status when one is provided.
+        if status and task["status"] != status:
             continue
 
-        # Instructor note: partial feature for the lab.
-        # The route already accepts `q`, but search is not implemented yet.
+        if query:
+            haystack = f"{task['title']} {task['description']}".lower()
+            if query not in haystack:
+                continue
+
         filtered.append(task)
 
     return filtered
@@ -53,12 +57,10 @@ def complete_task(task_id: int) -> dict[str, Any] | None:
 
     for task in tasks:
         if task["id"] == task_id:
-            updated_task = dict(task)
-            updated_task["status"] = "done"
-            updated_task["completed_at"] = datetime.now(timezone.utc).isoformat()
-
-            # Instructor note: intentional bug for the lab.
-            # The updated task is returned, but the stored list is never updated or saved.
-            return updated_task
+            task["status"] = "done"
+            task["completed_at"] = datetime.now(timezone.utc).isoformat()
+            # Persist the mutated task list so subsequent reads see the completion.
+            save_tasks(tasks)
+            return task
 
     return None


### PR DESCRIPTION
## Summary
- Fix `GET /tasks` status filtering so the handler compares against the requested status value instead of the literal string "status".
- Persist task completions by mutating the stored task, stamping `completed_at`, and saving via `save_tasks`, ensuring follow-up reads show the `done` state.
- Add case-insensitive `q` search across task title and description, and make sure it composes cleanly with the status filter.

## Testing
- `curl "http://127.0.0.1:8000/tasks?status=open"` → returns only open tasks.
- `curl "http://127.0.0.1:8000/tasks?status=done"` → returns only done tasks.
- `curl -X POST http://127.0.0.1:8000/tasks/3/complete` → returns task 3 with `status: done` and a populated `completed_at`.
- `curl http://127.0.0.1:8000/tasks/3` → task 3 remains `done` with the same timestamp.
- `curl "http://127.0.0.1:8000/tasks?q=launch"` → returns task 1.
- `curl "http://127.0.0.1:8000/tasks?status=done&q=plan"` → returns task 3, demonstrating combined filters work.